### PR TITLE
[Refactor] 버튼, 인풋 component 후 SignInForm 수정

### DIFF
--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -3,6 +3,15 @@ import Input from 'components/common/Input';
 import { AuthContext } from 'context/auth/AuthContext';
 import useFormValidation from 'hooks/useFormValidation';
 import { FormEvent, useContext } from 'react';
+import styled from 'styled-components';
+
+export const FormStyle = styled.form`
+  padding: 30px;
+  text-align: center;
+  button {
+    margin-top: 15px;
+  }
+`;
 
 export default function SignInForm() {
   const {
@@ -25,7 +34,7 @@ export default function SignInForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit}>
+    <FormStyle onSubmit={handleSubmit}>
       <Input
         name='email'
         value={email}
@@ -48,14 +57,7 @@ export default function SignInForm() {
         placeholder='비밀번호를 입력해주세요.'
         dataTestId='password-input'
       />
-      <Button
-        type='submit'
-        dataTestId='signin-button'
-        disabled={!isValid}
-        text='로그인'
-        btnWidth=''
-        btnPadding=''
-      />
-    </form>
+      <Button type='submit' dataTestId='signin-button' disabled={!isValid} text='로그인' />
+    </FormStyle>
   );
 }

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { ButtonHTMLAttributes } from 'react';
 import styled from 'styled-components';
 
 const ButtonStyle = styled.button`
@@ -13,32 +13,21 @@ const ButtonStyle = styled.button`
   }
 `;
 
-type Props = {
-  type?: React.ButtonHTMLAttributes<HTMLButtonElement>['type'];
+interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;
-  onBtnClick?: React.MouseEventHandler<HTMLButtonElement>;
-  dataTestId: string;
-  btnWidth: string;
-  btnPadding: string;
-  disabled: boolean;
-};
+  dataTestId?: string;
+  btnWidth?: string;
+  btnPadding?: string;
+}
 
-export default function Button(props: Props) {
-  const { type, text, onBtnClick, dataTestId, btnWidth, btnPadding, disabled } = props;
-
+export default function Button({ text, dataTestId, btnWidth, btnPadding, ...ButtonProps }: Props) {
   const styleChange = {
     width: btnWidth || '100%',
     padding: btnPadding || '13px',
   };
 
   return (
-    <ButtonStyle
-      type={type ? type : 'button'}
-      onClick={onBtnClick}
-      data-testid={dataTestId}
-      style={styleChange}
-      disabled={disabled}
-    >
+    <ButtonStyle data-testid={dataTestId} style={styleChange} {...ButtonProps}>
       {text}
     </ButtonStyle>
   );

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { InputHTMLAttributes } from 'react';
 import styled from 'styled-components';
 
 const InputStyle = styled.input`
@@ -21,36 +21,32 @@ const WarningText = styled.p`
   height: 28px;
 `;
 
-type Props = {
-  name: string;
-  value: string;
-  onChange: React.ChangeEventHandler<HTMLInputElement>;
-  type: string;
-  inputId: string;
-  labelText: string;
-  warning: string;
-  placeholder: string;
+interface Props extends InputHTMLAttributes<HTMLInputElement> {
   dataTestId: string;
-};
+  warning: string;
+  labelText: string;
+  inputId: string;
+  // ref: HTMLInputElement;
+}
 
-export default function Input(props: Props) {
-  const { name, value, onChange, type, inputId, labelText, warning, placeholder, dataTestId } =
-    props;
-
+export default function Input({
+  dataTestId,
+  warning,
+  labelText,
+  inputId,
+  // ref,
+  ...InputProps
+}: Props) {
   return (
     <>
       <label className='a11y-hidden' htmlFor={inputId}>
         {labelText}
       </label>
       <InputStyle
-        name={name}
-        value={value}
-        onChange={onChange}
-        type={type ? type : 'text'}
         id={inputId}
-        placeholder={placeholder}
         data-testid={dataTestId}
-        autoComplete={type === 'password' ? 'off' : 'on'}
+        {...InputProps}
+        // ref={ref}
       />
       <WarningText>{warning}</WarningText>
     </>


### PR DESCRIPTION
```ts
import { ButtonHTMLAttributes } from 'react';
import styled from 'styled-components';

const ButtonStyle = styled.button`
  border-radius: 15px;
  background: var(--color-white30);
  &:not(:disabled):hover {
    background: var(--color-white70);
    color: var(--color-blue);
  }
  &:disabled {
    cursor: initial;
  }
`;

interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
  text: string;
  dataTestId?: string;
  btnWidth?: string;
  btnPadding?: string;
}

export default function Button({ text, dataTestId, btnWidth, btnPadding, ...ButtonProps }: Props) {
  const styleChange = {
    width: btnWidth || '100%',
    padding: btnPadding || '13px',
  };

  return (
    <ButtonStyle data-testid={dataTestId} style={styleChange} {...ButtonProps}>
      {text}
    </ButtonStyle>
  );
}
```
신혁님이 말씀해주신대로 button과 input 컴포넌트를 바꿨습니다. 바꾼 것을 토대로 해당 컴포넌트를 사용한 곳을 일단 수정했습니다.